### PR TITLE
✨ Add mu keyword to rv/sv conversions

### DIFF
--- a/src/orbit/conversions.jl
+++ b/src/orbit/conversions.jl
@@ -2,6 +2,10 @@
 #
 # Conversion between the orbit representations using Julia built-in system.
 #
+# `convert` takes no options, so the conversions between Keplerian elements and orbit state
+# vectors use the default central body (Earth). Call `kepler_to_sv` or `sv_to_kepler` with
+# the keyword `μ` for an orbit around another body.
+#
 ############################################################################################
 
 function Base.convert(

--- a/src/orbit/kepler_to_rv.jl
+++ b/src/orbit/kepler_to_rv.jl
@@ -18,7 +18,7 @@
 export kepler_to_rv
 
 """
-    kepler_to_rv(ke::KeplerianElements{Tepoch, T}) where {Tepoch <: Number, T <: Number} -> SVector{3, T}, SVector{3, T}
+    kepler_to_rv(ke::KeplerianElements{Tepoch, T}; μ::Number = GM_EARTH) where {Tepoch <: Number, T <: Number} -> SVector{3, T}, SVector{3, T}
 
 Convert the Keplerian elements `ke` to a Cartesian representation (position vector `r` [m]
 and velocity vector `v` [m / s]).
@@ -28,10 +28,15 @@ and velocity vector `v` [m / s]).
     The returned vectors are represented in the same reference frame as the Keplerian
     elements.
 
+# Keywords
+
+- `μ::Number`: Standard gravitational parameter of the central body [m³ / s²].
+    (**Default** = `GM_EARTH`)
+
 # Returns
 
 - `SVector{3, T}`: The position vector represented in the inertial reference frame [m].
-- `SVector{3, T}`: The velocity vector represented in the inertial reference frame [m].
+- `SVector{3, T}`: The velocity vector represented in the inertial reference frame [m / s].
 
 # Remarks
 
@@ -44,7 +49,10 @@ This algorithm was adapted from **[1]** and **[2]**(p. 37-38).
 - **[2]**: Kuga, H. K., Carrara, V., Rao, K. R (2005). Introdução à Mecânica Orbital. 2ª ed.
     Instituto Nacional de Pesquisas Espaciais.
 """
-function kepler_to_rv(ke::KeplerianElements{Tepoch, T}) where {Tepoch <: Number, T <: Number}
+function kepler_to_rv(
+    ke::KeplerianElements{Tepoch, T};
+    μ::Number = GM_EARTH
+) where {Tepoch <: Number, T <: Number}
     # Unpack.
     a = ke.a
     e = ke.e
@@ -60,7 +68,7 @@ function kepler_to_rv(ke::KeplerianElements{Tepoch, T}) where {Tepoch <: Number,
     sin_f, cos_f = sincos(f)
     e² = e * e
 
-    # Compute the geocentric distance.
+    # Compute the distance to the center of the central body.
     r = a * (1 - e²) / (1 + e * cos_f)
 
     # Compute the position vector in the orbit plane, defined as:
@@ -70,7 +78,7 @@ function kepler_to_rv(ke::KeplerianElements{Tepoch, T}) where {Tepoch <: Number,
     r_o = SVector{3, T}(r * cos_f, r * sin_f, 0)
 
     # Compute the velocity vector in the orbit plane without perturbations.
-    n₀  = √(T(GM_EARTH) / T(a)^3)
+    n₀  = √(T(μ) / T(a)^3)
     v_o = n₀ * a / sqrt(1 - e²) * SVector{3, T}(-sin_f, e + cos_f, 0)
 
     # Compute the matrix that rotates the orbit reference frame into the inertial reference

--- a/src/orbit/kepler_to_sv.jl
+++ b/src/orbit/kepler_to_sv.jl
@@ -7,15 +7,20 @@
 export kepler_to_sv
 
 """
-    kepler_to_sv(ke::KeplerianElements) -> OrbitStateVector
+    kepler_to_sv(ke::KeplerianElements; μ::Number = GM_EARTH) -> OrbitStateVector
 
 Convert the Keplerian elements `ke` to the orbit state vector.
 
 !!! note
 
     The acceleration in the orbit state vector will be set to 0.
+
+# Keywords
+
+- `μ::Number`: Standard gravitational parameter of the central body [m³ / s²].
+    (**Default** = `GM_EARTH`)
 """
-function kepler_to_sv(ke::KeplerianElements)
-    r_i, v_i = kepler_to_rv(ke)
+function kepler_to_sv(ke::KeplerianElements; μ::Number = GM_EARTH)
+    r_i, v_i = kepler_to_rv(ke; μ)
     return OrbitStateVector(ke.t, r_i, v_i)
 end

--- a/src/orbit/rv_to_kepler.jl
+++ b/src/orbit/rv_to_kepler.jl
@@ -15,7 +15,7 @@
 export rv_to_kepler
 
 """
-    rv_to_kepler(r_i::AbstractVector{T1}, v_i::AbstractVector{T2}, t::T3 = 0) where {T1<:Number, T2<:Number, T3<:Number} -> KeplerianElements{Tepoch, T}
+    rv_to_kepler(r_i::AbstractVector{T1}, v_i::AbstractVector{T2}, t::T3 = 0; μ::Number = GM_EARTH) where {T1<:Number, T2<:Number, T3<:Number} -> KeplerianElements{Tepoch, T}
 
 Convert a Cartesian representation (position vector `r_i` [m] and velocity vector `v_i`
 [m / s]) to Keplerian elements. Optionally, the user can specify the epoch of the returned
@@ -25,6 +25,11 @@ elements using the parameter `t`. It it is omitted, then it defaults to 0.
 
     The output type `Tepoch` is obtained by converting `T3` to float, whereas the output
     type `T` is obtained by promoting `T1` and `T2` and converting the result to float.
+
+# Keywords
+
+- `μ::Number`: Standard gravitational parameter of the central body [m³ / s²].
+    (**Default** = `GM_EARTH`)
 
 # Returns
 
@@ -51,7 +56,8 @@ The special cases are treated as follows:
 function rv_to_kepler(
     r_i::AbstractVector{T1},
     v_i::AbstractVector{T2},
-    t::T3 = 0
+    t::T3 = 0;
+    μ::Number = GM_EARTH
 ) where {T1<:Number, T2<:Number, T3<:Number}
     # Check inputs.
     length(r_i) != 3 && error("The vector r_i must have 3 dimensions.")
@@ -73,7 +79,7 @@ function rv_to_kepler(
         v  = sqrt(v²)
         rv = dot(sr_i, sv_i)
 
-        μ  = T(GM_EARTH)
+        μ  = T(μ)
 
         # Angular momentum vector.
         h_i = sr_i × sv_i

--- a/src/orbit/sv_to_kepler.jl
+++ b/src/orbit/sv_to_kepler.jl
@@ -7,10 +7,15 @@
 export sv_to_kepler
 
 """
-    sv_to_kepler(sv::OrbitStateVector) -> KeplerianElements
+    sv_to_kepler(sv::OrbitStateVector; μ::Number = GM_EARTH) -> KeplerianElements
 
 Convert the orbit state vector `sv` to Keplerian elements.
+
+# Keywords
+
+- `μ::Number`: Standard gravitational parameter of the central body [m³ / s²].
+    (**Default** = `GM_EARTH`)
 """
-function sv_to_kepler(sv::OrbitStateVector)
-    return rv_to_kepler(sv.r, sv.v, sv.t)
+function sv_to_kepler(sv::OrbitStateVector; μ::Number = GM_EARTH)
+    return rv_to_kepler(sv.r, sv.v, sv.t; μ)
 end

--- a/test/orbit/conversions.jl
+++ b/test/orbit/conversions.jl
@@ -223,6 +223,38 @@ end
     @test_throws ArgumentError rv_to_kepler(r_i, v_i)
 end
 
+@testset "Functions kepler_to_rv and rv_to_kepler (Custom Central Body)" begin
+    # A circular orbit has a constant speed of √(μ / a). We use that identity as the
+    # reference, so the test does not depend on the central body being the Earth. The orbit
+    # here is around the Moon, whose standard gravitational parameter is 4.902800118e12
+    # m³ / s² (DE440).
+    μ = 4.902800118e12
+
+    # == Float64 ===========================================================================
+
+    let
+        a  = 1837.4e3
+        ke = KeplerianElements(0.0, a, 0.0, 85 |> deg2rad, 30 |> deg2rad, 0.0, 0.0)
+
+        r_i, v_i = kepler_to_rv(ke; μ)
+
+        @test norm(v_i) ≈ √(μ / a)
+        @test rv_to_kepler(r_i, v_i, ke.t; μ).a ≈ a
+    end
+
+    # == Float32 ===========================================================================
+
+    let
+        a  = 1837.4f3
+        ke = KeplerianElements(0.0f0, a, 0.0f0, 85f0 |> deg2rad, 0.0f0, 0.0f0, 0.0f0)
+
+        _, v_i = kepler_to_rv(ke; μ)
+
+        @test norm(v_i) ≈ √(Float32(μ) / a)
+        @test eltype(v_i) == Float32
+    end
+end
+
 # == Files: ./src/orbit/kepler_to_sv.jl and ./src/orbit/sv_to_kepler.jl ====================
 
 # -- Functions: kepler_to_sv and sv_to_kepler ----------------------------------------------
@@ -367,6 +399,17 @@ end
         @test f * 180 / π    ≈ 92.335    atol = 1e-3
         @test ke isa KeplerianElements{Float32, Float32}
     end
+end
+
+@testset "Functions kepler_to_sv and sv_to_kepler (Custom Central Body)" begin
+    μ  = 4.902800118e12
+    a  = 1837.4e3
+    ke = KeplerianElements(0.0, a, 0.0, 85 |> deg2rad, 30 |> deg2rad, 0.0, 0.0)
+
+    sv = kepler_to_sv(ke; μ)
+
+    @test sv.v ≈ last(kepler_to_rv(ke; μ))
+    @test sv_to_kepler(sv; μ).a ≈ a
 end
 
 # == Files: ./src/orbit/conversions.jl =====================================================

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 
 using Dates
+using LinearAlgebra
 using SatelliteToolboxBase
 using StaticArrays
 


### PR DESCRIPTION
Currently the `kepler_to_rv`/`kepler_to_sv` and `rv_to_kepler`/`sv_to_kepler` methods use `GM_EARTH` for all conversions.

This PR adds a keyword `μ` to those methods, which is necessary to perform state conversions for other central bodies. 
The keyword defaults to `GM_EARTH`, so doesn't break anything.
